### PR TITLE
Resolved python3 TypeError

### DIFF
--- a/python_examples/README.md
+++ b/python_examples/README.md
@@ -1,8 +1,11 @@
 # Python Examples
 
 [![Downloads](https://pepy.tech/badge/pysinric)](https://pepy.tech/project/pysinric) [![Downloads](https://pepy.tech/badge/pysinric/week)](https://pepy.tech/project/pysinric/week) [![](https://img.shields.io/pypi/format/pysinric.svg)]() [![](https://img.shields.io/badge/author-Dhanush-brightgreen.svg)](https://github.com/dazzHere)
-### Install sinric into your python env
-   `pip install pysinric --user`
+### Install sinric python package
+    pip install pysinric --user
 
 ### Pysinric
    [pysinric](https://pypi.org/project/pysinric/)
+   
+### Upgrade Pysinric to lastest version
+    python -m pip install pysinric --upgrade

--- a/python_examples/examples/test.py
+++ b/python_examples/examples/test.py
@@ -1,8 +1,7 @@
 from sinric import Sinric
 from time import sleep
 
-apiKey = 'Replace with your api Key'  # https://sinric.com
-
+apiKey = 'Your api Key'  # https://sinric.com
 response = any
 
 obj = Sinric(apiKey)
@@ -10,3 +9,4 @@ while True:
     response = obj.initialize()
     print(response) #Prints response
     sleep(2)
+ 

--- a/python_examples/setup.py
+++ b/python_examples/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.0.3"
+VERSION = "0.0.4"
 
 with open('README.rst', 'r') as f:
     long_description = f.read()

--- a/python_examples/sinric/sinric.py
+++ b/python_examples/sinric/sinric.py
@@ -1,21 +1,15 @@
 import websocket
-import threading
-import time
-import base64
-import json
-from collections import OrderedDict
-
+from base64 import b64encode as enc
 
 
 class Sinric:
     def __init__(self, apikey):
-        self.apikey = apikey
+        self.apikey = apikey.encode('ascii')
 
     def initialize(self):
         websocket.enableTrace(True)
         ws = websocket.create_connection('ws://iot.sinric.com',
-                                         header={'Authorization:' + base64.b64encode('apikey:' + self.apikey)})
-        # print("Sent")
+                                         header={'Authorization:' + enc(b'apikey:'+self.apikey).decode('ascii')})
         response = ws.recv()
         ws.close()
         return response


### PR DESCRIPTION
b64encode threw and error `TypeError: a bytes-like object is required, not 'str'`. Solved this error by encoding header string with `utf-8` and decoding it back while sending the request.